### PR TITLE
Allow host to include https

### DIFF
--- a/src/bitcoinrpc/bitcoin_rpc.py
+++ b/src/bitcoinrpc/bitcoin_rpc.py
@@ -56,8 +56,10 @@ class BitcoinRPC:
         await self.aclose()
 
     @staticmethod
-    def _set_url(host: str, port: int) -> str:
-        return f"http://{host}:{port}"
+    def _set_url(host: str, port: int, **options: Any) -> str:
+        if not 'http' in host:
+            return f"http://{host}:{port}"
+        return f"{host}:{port}"
 
     @staticmethod
     def _configure_client(


### PR DESCRIPTION
Make it optional if the host should include the http protocol, i.e ```https://bitcoind-host``` instead of ```bitcoind-host```