### PR TITLE
Fix request counter not being reset between instantiations of `BitcoinRPC` client

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,46 @@
+import typing as t
+
+import httpx
+import orjson
+import pytest
+
+from bitcoinrpc import BitcoinRPC
+
+
+@pytest.mark.asyncio
+async def test_two_clients_dont_share_counter(rpc_config: t.Dict[str, t.Any]) -> None:
+    logs: t.List[bytes] = []
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        """
+        Mock the JSON-RPC response so this test does not rely on a running Bitcoin Node
+        """
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": 0})
+
+    async def log_request(request: httpx.Request) -> None:
+        """
+        Hook that stores the serialized request before it is sent over the wire.
+        """
+        nonlocal logs
+        logs.append(orjson.loads(request.content))
+
+    url, auth = rpc_config["url"], rpc_config["auth"]
+    client1 = httpx.AsyncClient(
+        auth=auth,
+        event_hooks={"request": [log_request]},
+        transport=httpx.MockTransport(handler=handler),
+    )
+    client2 = httpx.AsyncClient(
+        auth=auth,
+        event_hooks={"request": [log_request]},
+        transport=httpx.MockTransport(handler=handler),
+    )
+
+    async with BitcoinRPC(url=url, client=client1) as rpc1:
+        _ = await rpc1.getblockcount()
+
+    async with BitcoinRPC(url=url, client=client2) as rpc2:
+        _ = await rpc2.getblockcount()
+
+    req1, req2 = logs
+    assert req1 == req2


### PR DESCRIPTION
If you run the test introduced in 0575f7b0685a53c6ee3b31a394bc63b5155b7d20 without the subsequent commit - e6600b716fa37df2f6990ee876e4ad7392950843 , you will see it fail in the following way:

```python
$ tox -e py311 -- tests/test_client.py
.pkg: _optional_hooks> python /home/rocket-boy/.virtualenvs/bench/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /home/rocket-boy/.virtualenvs/bench/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /home/rocket-boy/.virtualenvs/bench/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /home/rocket-boy/.virtualenvs/bench/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /home/rocket-boy/.virtualenvs/bench/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py311: install_package> python -I -m pip install --force-reinstall --no-deps /home/rocket-boy/Desktop/Programming/bitcoin-python-async-rpc/.tox/.tmp/package/38/bitcoinrpc-0.6.1.tar.gz
py311: commands[0]> pytest -c setup.cfg tests/test_client.py
============================================================================ test session starts ============================================================================
platform linux -- Python 3.11.5, pytest-8.0.0, pluggy-1.4.0 -- /home/rocket-boy/Desktop/Programming/bitcoin-python-async-rpc/.tox/py311/bin/python
cachedir: .tox/py311/.pytest_cache
rootdir: /home/rocket-boy/Desktop/Programming/bitcoin-python-async-rpc
configfile: setup.cfg
plugins: asyncio-0.23.5, anyio-4.2.0
asyncio: mode=Mode.STRICT
collected 1 item                                                                                                                                                            

tests/test_client.py::test_two_clients_dont_share_counter FAILED                                                                                                      [100%]

================================================================================= FAILURES ==================================================================================
____________________________________________________________________ test_two_clients_dont_share_counter ____________________________________________________________________

rpc_config = {'auth': ('rpc_user', 'rpc_password'), 'url': 'http://localhost:18443'}

    @pytest.mark.asyncio
    async def test_two_clients_dont_share_counter(rpc_config: t.Dict[str, t.Any]) -> None:
        logs: t.List[bytes] = []
    
        def handler(_: httpx.Request) -> httpx.Response:
            """
            Mock the JSON-RPC response so this test does not rely on a running Bitcoin Node
            """
            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": 0})
    
        async def log_request(request: httpx.Request) -> None:
            """
            Hook that stores the serialized request before it is sent over the wire.
            """
            nonlocal logs
            logs.append(orjson.loads(request.content))
    
        url, auth = rpc_config["url"], rpc_config["auth"]
        client1 = httpx.AsyncClient(
            auth=auth,
            event_hooks={"request": [log_request]},
            transport=httpx.MockTransport(handler=handler),
        )
        client2 = httpx.AsyncClient(
            auth=auth,
            event_hooks={"request": [log_request]},
            transport=httpx.MockTransport(handler=handler),
        )
    
        async with BitcoinRPC(url=url, client=client1) as rpc1:
            _ = await rpc1.getblockcount()
    
        async with BitcoinRPC(url=url, client=client2) as rpc2:
            _ = await rpc2.getblockcount()
    
        req1, req2 = logs
>       assert req1 == req2
E       AssertionError: assert {'jsonrpc': '2.0', 'id': 1, 'method': 'getblockcount', 'params': []} == {'jsonrpc': '2.0', 'id': 2, 'method': 'getblockcount', 'params': []}
E         
E         Common items:
E         {'jsonrpc': '2.0', 'method': 'getblockcount', 'params': []}
E         Differing items:
E         {'id': 1} != {'id': 2}
E         
E         Full diff:
E           {
E         -     'id': 2,
E         ?           ^
E         +     'id': 1,
E         ?           ^
E               'jsonrpc': '2.0',
E               'method': 'getblockcount',
E               'params': [],
E           }

tests/test_client.py:46: AssertionError
========================================================================== short test summary info ==========================================================================
FAILED tests/test_client.py::test_two_clients_dont_share_counter - AssertionError: assert {'jsonrpc': '2.0', 'id': 1, 'method': 'getblockcount', 'params': []} == {'jsonrpc': '2.0', 'id': 2, 'method': 'getblockcount', 'params': []}
============================================================================= 1 failed in 0.06s =============================================================================
py311: exit 1 (0.24 seconds) /home/rocket-boy/Desktop/Programming/bitcoin-python-async-rpc> pytest -c setup.cfg tests/test_client.py pid=5778
.pkg: _exit> python /home/rocket-boy/.virtualenvs/bench/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py311: FAIL code 1 (0.97=setup[0.73]+cmd[0.24] seconds)
  evaluation failed :( (1.01 seconds)
```

---

### The gist of that test is the following:

During a single test, instantiate the `BitcoinRPC` twice, do the same RPC call with each of them and compare the **requests** emitted by both. One would expect they were equal. It turns out, they differ in the `id` field - it is shared across all instances, instead of being reset.

---

Subsequent commit e6600b716fa37df2f6990ee876e4ad7392950843 fixes the issue.