### PR TITLE
Add 'TypedDict' models conforming to JSON-RPC 2.0 spec 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 orjson>=3
 httpx<1
-typing_extensions>=3.7.4.3
+typing_extensions>=4.0.0

--- a/src/bitcoinrpc/_exceptions.py
+++ b/src/bitcoinrpc/_exceptions.py
@@ -1,4 +1,13 @@
+from bitcoinrpc._spec import Error, RequestId
+
+
 class RPCError(Exception):
-    def __init__(self, code: int, message: str) -> None:
-        self.code = code
-        self.message = message
+    """
+    Enrich the `Error` - https://www.jsonrpc.org/specification#error_object
+    with the `id` of the request that caused the error.
+    """
+
+    def __init__(self, id: RequestId, error: Error) -> None:
+        super().__init__(error["message"])
+        self.id = id
+        self.error = error

--- a/src/bitcoinrpc/_spec.py
+++ b/src/bitcoinrpc/_spec.py
@@ -1,0 +1,82 @@
+"""
+Module containing definitions of objects (described as Python's Typed dictionaries)
+taken from JSON-RPC 2.0 specification.
+
+https://www.jsonrpc.org/specification
+"""
+
+from typing import List, Optional, Union
+
+from typing_extensions import NotRequired, TypedDict
+
+from bitcoinrpc._types import JSONType
+
+RequestId = Union[int, str, None]
+"""
+https://www.jsonrpc.org/specification#request_object
+
+According to the specification, must be String, Integer or Null.
+"""
+
+
+class Request(TypedDict):
+    """
+    https://www.jsonrpc.org/specification#request_object
+
+    `jsonrpc` member is always "2.0"
+    """
+
+    jsonrpc: str
+    id: RequestId
+    method: str
+    params: List[JSONType]
+
+
+class Error(TypedDict):
+    """
+    https://www.jsonrpc.org/specification#error_object
+
+    `data` member may not be present at all.
+    """
+
+    code: int
+    message: str
+    data: NotRequired[JSONType]
+
+
+class _ResponseCommon(TypedDict):
+    jsonrpc: str
+    id: RequestId
+
+
+class ResponseSuccess(_ResponseCommon):
+    """
+    https://www.jsonrpc.org/specification#response_object
+
+    - `jsonrpc` member is always "2.0"
+    - `result` member is always present and is a valid JSON
+    - `error` should not be present by the specification, but at least Bitcoin Node
+        as of version v26.0 always includes `error` member with value `NULL` on the
+        success path.
+    """
+
+    result: JSONType
+    error: NotRequired[Optional[Error]]
+
+
+class ResponseError(_ResponseCommon):
+    """
+    https://www.jsonrpc.org/specification#response_object
+
+    - `jsonrpc` member is always "2.0"
+    - `result` should not be present by the specification, but at least Bitcoin Node
+        as of version v26.0 always includes `result` member with value `NULL` on the
+        error path.
+    - `error` member is always present and is a JSON of `Error` shape defined above.
+    """
+
+    result: NotRequired[Optional[JSONType]]
+    error: Error
+
+
+Response = Union[ResponseSuccess, ResponseError]


### PR DESCRIPTION
Said models are used to clarify shape on the success/error paths
within 'BitcoinRPC.acall' coroutine method.

**Breaking change**: change the handling of responses with non-2xx
  status codes in 'BitcoinRPC.acall'.

Previously, said errors would be raised directly via the
'httpx.Response.raise_for_status' method.

Now, 'httpx.Response.raise_for_status' is used only when the server
returns an empty response, which may happen due to for example bad
authentication. In all other cases, defer the decision whether RPC
call was a success or a failure to the inspection of return JSON.

Adjust tests to reflect the aforementioned change.

---

Also, bump minimal version of `typing-extensions` to 4.0.0 since that's when `NotRequired` was introduced.